### PR TITLE
adds config for short names and arg label values

### DIFF
--- a/google/tracer.go
+++ b/google/tracer.go
@@ -5,7 +5,7 @@ import (
 
 	"cloud.google.com/go/trace"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
+	"github.com/promoboxx/instrumentedsql"
 )
 
 type tracer struct{}

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
+	"github.com/promoboxx/instrumentedsql"
 )
 
 type tracer struct{}

--- a/opts.go
+++ b/opts.go
@@ -16,3 +16,19 @@ func WithTracer(t Tracer) Opt {
 		w.Tracer = t
 	}
 }
+
+// DisableArgsLabel will prevent the spans from submitting
+// any of the argument data with the spans in case it is sensitive data
+func DisableArgsLabel(t Tracer) Opt {
+	return func(w *wrappedDriver) {
+		w.withArgsLabel = false
+	}
+}
+
+// WithShortQueryNames changes the query labels on the spans to be shortened versions
+// i.e `find_user($1, $2, $3, $4, $5)` --> `find_user`
+func WithShortQueryNames(t Tracer) Opt {
+	return func(w *wrappedDriver) {
+		w.shortQueryName = true
+	}
+}

--- a/sql_example_test.go
+++ b/sql_example_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/mattn/go-sqlite3"
 
-	"github.com/ExpansiveWorlds/instrumentedsql"
-	"github.com/ExpansiveWorlds/instrumentedsql/google"
-	"github.com/ExpansiveWorlds/instrumentedsql/opentracing"
+	"github.com/promoboxx/instrumentedsql"
+	"github.com/promoboxx/instrumentedsql/google"
+	"github.com/promoboxx/instrumentedsql/opentracing"
 )
 
 // WrapDriverGoogle demonstrates how to call wrapDriver and register a new driver.


### PR DESCRIPTION
Provide a way to configure some of the labels being set. Some query names with string replace characters may exceed span name limits (datadog has max limit of 100 chars) and being able to ignore query args keeps sensitive data from being put into data dog, such as user emails, names, and other private information.

Adds:
1. `Opts` for creating short query names and for using query args